### PR TITLE
IMU基板から送られてくるデータとチェックサムの計算と照合を実装した

### DIFF
--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -63,8 +63,8 @@ private:
         char command[2] = {0};
         char command2[50] = {0};
         char temp[6];
-	unsigned long int sum = 0;
-	
+        unsigned long int sum = 0;
+        
         const float temp_unit = 0.00565;
         
         sprintf(command, "o");
@@ -76,24 +76,24 @@ private:
         ROS_INFO_STREAM("recv = " << command2);
 
         memmove(temp,command2,4);
-	sum = sum ^ ((short)strtol(temp, NULL, 16));
+        sum = sum ^ ((short)strtol(temp, NULL, 16));
         data.angular_deg[0] = ((short)strtol(temp, NULL, 16)) * gyro_unit;
         memmove(temp,command2+4,4);
-	sum = sum ^ ((short)strtol(temp, NULL, 16));
+        sum = sum ^ ((short)strtol(temp, NULL, 16));
         data.angular_deg[1] = ((short)strtol(temp, NULL, 16)) * gyro_unit;
         memmove(temp,command2+8,4);
-	sum = sum ^ ((short)strtol(temp, NULL, 16));
+        sum = sum ^ ((short)strtol(temp, NULL, 16));
         data.angular_deg[2] = ((short)strtol(temp, NULL, 16)) * gyro_unit * z_axis_dir_;
 
-	memmove(temp,command2+12,4);
-	
-	if( sum != ((short)strtol(temp,NULL,16)))
-	{
-		//throw "Exception: Invalid IMU Data\n";
-		ROS_WARN_STREAM("Invaid IMU Data:"<<command2);
-		ROS_WARN_STREAM("Recv Checksum:"<<((short)strtol(temp,NULL,16)));
-		ROS_WARN_STREAM("Calculate Checksum:"<<sum);
-	}
+        memmove(temp,command2+12,4);
+        
+        if( sum != ((short)strtol(temp,NULL,16)))
+        {
+                //throw "Exception: Invalid IMU Data\n";
+                ROS_WARN_STREAM("Invaid IMU Data:"<<command2);
+                ROS_WARN_STREAM("Recv Checksum:"<<((short)strtol(temp,NULL,16)));
+                ROS_WARN_STREAM("Calculate Checksum:"<<sum);
+        }
         //while(data.angular_deg[2] < -180) data.angular_deg[2] += 180;
         //while(data.angular_deg[2] > 180) data.angular_deg[2] -= 180;
 
@@ -172,14 +172,14 @@ public:
         //コンフィギュレーション リセット
         // if(m_reset == true){
         sprintf(command, "0");
-        usb.Send(command, strlen(command));	//送信
+        usb.Send(command, strlen(command));        //送信
         std::cout << "send = " << command << std::endl;
         sleep(1);
         std::cout << "Gyro 0 Reset" << std::endl;
         // }
         geta = 0;
-        usb.Recv(command2, 100);	//空読み バッファクリアが効かない？
-        usb.ClearRecvBuf();		//バッファクリア
+        usb.Recv(command2, 100);        //空読み バッファクリアが効かない？
+        usb.ClearRecvBuf();                //バッファクリア
         return true;
     }
 

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -63,6 +63,8 @@ private:
         char command[2] = {0};
         char command2[50] = {0};
         char temp[6];
+	unsigned long int sum = 0;
+	
         const float temp_unit = 0.00565;
         
         sprintf(command, "o");
@@ -74,29 +76,24 @@ private:
         ROS_INFO_STREAM("recv = " << command2);
 
         memmove(temp,command2,4);
+	sum = sum ^ ((short)strtol(temp, NULL, 16));
         data.angular_deg[0] = ((short)strtol(temp, NULL, 16)) * gyro_unit;
         memmove(temp,command2+4,4);
+	sum = sum ^ ((short)strtol(temp, NULL, 16));
         data.angular_deg[1] = ((short)strtol(temp, NULL, 16)) * gyro_unit;
         memmove(temp,command2+8,4);
+	sum = sum ^ ((short)strtol(temp, NULL, 16));
         data.angular_deg[2] = ((short)strtol(temp, NULL, 16)) * gyro_unit * z_axis_dir_;
 
-        memmove(temp,command2+12,4);
-        data.linear_acc[0] = ((short)strtol(temp, NULL, 16)) * acc_unit;
-        memmove(temp,command2+16,4);
-        data.linear_acc[1] = ((short)strtol(temp, NULL, 16)) * acc_unit;
-        memmove(temp,command2+20,4);
-        data.linear_acc[2] = init_angle + ((short)strtol(temp, NULL, 16)) * acc_unit ;
-
-        memmove(temp,command2+24,4);
-        data.angular_vel[0] = ((short)strtol(temp, NULL, 16)) * gyro_unit;
-        memmove(temp,command2+28,4);
-        data.angular_vel[1] = ((short)strtol(temp, NULL, 16)) * gyro_unit;
-        memmove(temp,command2+30,4);
-        data.angular_vel[2] = ((short)strtol(temp, NULL, 16)) * gyro_unit;
-
-        memmove(temp,command2+24,4);
-        data.temp = ((short)strtol(temp, NULL, 16)) * temp_unit + 25.0;
-        
+	memmove(temp,command2+12,4);
+	
+	if( sum != ((short)strtol(temp,NULL,16)))
+	{
+		//throw "Exception: Invalid IMU Data\n";
+		ROS_WARN_STREAM("Invaid IMU Data:"<<command2);
+		ROS_WARN_STREAM("Recv Checksum:"<<((short)strtol(temp,NULL,16)));
+		ROS_WARN_STREAM("Calculate Checksum:"<<sum);
+	}
         //while(data.angular_deg[2] < -180) data.angular_deg[2] += 180;
         //while(data.angular_deg[2] > 180) data.angular_deg[2] -= 180;
 

--- a/src/imu.cpp
+++ b/src/imu.cpp
@@ -25,17 +25,10 @@ bool isInRange(T value, T max, T min){
 
 struct ImuData {
     double angular_deg[3];
-    double linear_acc[3];
-    double angular_vel[3];
-    double temp;
-
-    ImuData() : 
-        temp(0)
-    {
+    
+    ImuData(){
         for(int i=0; i < 2; i++){
             angular_deg[i] = 0;
-            linear_acc[i] = 0;
-            angular_vel[i] = 0;
         }
     }
 };
@@ -208,13 +201,7 @@ public:
             }
 
             output_msg.orientation = tf::createQuaternionMsgFromYaw(deg_to_rad(data.angular_deg[2]));
-            output_msg.linear_acceleration.x = data.linear_acc[0];
-            output_msg.linear_acceleration.y = data.linear_acc[1];
-            output_msg.linear_acceleration.z = data.linear_acc[2];
-            output_msg.angular_velocity.x = data.angular_vel[0];
-            output_msg.angular_velocity.y = data.angular_vel[1];
-            output_msg.angular_velocity.z = data.angular_vel[2];
-    
+                
             //ROS_INFO_STREAM("temp = " << data.temp);
             
             imu_pub_.publish(output_msg);


### PR DESCRIPTION
IMU基板でチェックサムを計算して送信するようにしたので、ROS側でも計算と照合を実装した。また、データの取りこぼしをなるべく防ぐために取得するデータを角度情報のみとした。
