### PR TITLE
Support for receied x-axis acceralation as pitch angle

### DIFF
--- a/src/imu_node.cpp
+++ b/src/imu_node.cpp
@@ -201,6 +201,8 @@ public:
 
     void run() {
         double old_angular_z_deg = getImuData().angular_deg[2];
+        double y_deg_tmp[10]={};
+        int y_deg_avg_cnt=0;
         double angular_z_deg = 0;
         unsigned short abnormal_count = 0;
 
@@ -219,7 +221,7 @@ public:
                     output_msg.header.frame_id = imu_frame_;
                     output_msg.header.stamp = ros::Time::now();
                       
-                    // ROS_INFO_STREAM("x_deg = " << data.angular_deg[0]);
+                    // ROS_INFO_STREAM("y_deg = " << data.angular_deg[0]);
                     ROS_INFO_STREAM("y_deg = " << rad_to_deg(data.angular_deg[1]));
                     ROS_INFO_STREAM("z_deg = " << data.angular_deg[2]);
                       
@@ -234,9 +236,19 @@ public:
                         abnormal_count = 0;
                         angular_z_deg = data.angular_deg[2];
                     }
-                    output_rpy.data.push_back(data.angular_deg[1]);
+                    y_deg_tmp[y_deg_avg_cnt]=data.angular_deg[1];
+                    double y_deg_sum=0;
+                    for(int i=0;i<10;i++){
+                        y_deg_sum += y_deg_tmp[i];
+                    }
+                    double y_deg_avg = y_deg_sum / 10;
+                    y_deg_avg_cnt++;
+                    if(y_deg_avg_cnt>9){
+                        y_deg_avg_cnt = 0;
+                    }
+                    output_rpy.data.push_back(y_deg_avg);
                     output_rpy.data.push_back(deg_to_rad(angular_z_deg));
-                    q = tf::createQuaternionFromRPY(0.0, data.angular_deg[1], deg_to_rad(angular_z_deg));
+                    q = tf::createQuaternionFromRPY(0.0, y_deg_avg, deg_to_rad(angular_z_deg));
                     tf::quaternionTFToMsg(q, output_msg.orientation);
                     imu_rpy_pub_.publish(output_rpy);
                     imu_pub_.publish(output_msg);

--- a/src/imu_node.cpp
+++ b/src/imu_node.cpp
@@ -231,7 +231,7 @@ public:
                         angular_z_deg = data.angular_deg[2];
                     }
                     
-                    q = tf::createQuaternionFromRPY(data.angular_deg[1], 0.0, deg_to_rad(angular_z_deg));
+                    q = tf::createQuaternionFromRPY(0.0, data.angular_deg[1], deg_to_rad(angular_z_deg));
                     tf::quaternionTFToMsg(q, output_msg.orientation);
                     imu_pub_.publish(output_msg);
                     old_angular_z_deg = angular_z_deg;

--- a/src/imu_node.cpp
+++ b/src/imu_node.cpp
@@ -147,7 +147,7 @@ public:
         imu_pub_(node.advertise<sensor_msgs::Imu>("imu", 10)),
         reset_service_(node.advertiseService("imu_reset", &IMU::resetCallback, this)), 
         carivrate_service_(node.advertiseService("imu_caribrate", &IMU::caribrateCallback, this)),
-        gyro_unit_(0.00836181640625), acc_unit_(0.0008192),
+        gyro_unit_(0.00836181640625), acc_unit_(0.0008192),imu_frame_("imu_link"),
         port_name_("/dev/ttyUSB0"), baudrate_(115200), loop_rate_(50), z_axis_dir_(-1), y_axis_dir_(-1)
     {
         ros::NodeHandle private_nh("~");

--- a/src/imu_node.cpp
+++ b/src/imu_node.cpp
@@ -90,7 +90,7 @@ private:
         data.angular_deg[0] = ((short)strtol(temp, NULL, 16)) * gyro_unit_;
         memmove(temp,command2+4,4);
         sum = sum ^ ((short)strtol(temp, NULL, 16));
-        data.angular_deg[1] = std::asin(((short)strtol(temp, NULL, 16)) * acc_unit) * y_axis_dir_;
+        data.angular_deg[1] = std::asin(((short)strtol(temp, NULL, 16)) * acc_unit_) * y_axis_dir_;
         memmove(temp,command2+8,4);
         sum = sum ^ ((short)strtol(temp, NULL, 16));
         data.angular_deg[2] = ((short)strtol(temp, NULL, 16)) * gyro_unit_ * z_axis_dir_;
@@ -147,8 +147,8 @@ public:
         imu_pub_(node.advertise<sensor_msgs::Imu>("imu", 10)),
         reset_service_(node.advertiseService("imu_reset", &IMU::resetCallback, this)), 
         carivrate_service_(node.advertiseService("imu_caribrate", &IMU::caribrateCallback, this)),
-        geta(0), gyro_unit(0.00836181640625), acc_unit(0.0008192), init_angle(0.0),
-        port_name("/dev/ttyUSB0"), baudrate(115200), loop_rate(50), z_axis_dir_(-1), y_axis_dir_(-1)
+        gyro_unit_(0.00836181640625), acc_unit_(0.0008192),
+        port_name_("/dev/ttyUSB0"), baudrate_(115200), loop_rate_(50), z_axis_dir_(-1), y_axis_dir_(-1)
     {
         ros::NodeHandle private_nh("~");
         private_nh.getParam("port_name", port_name_);
@@ -159,7 +159,7 @@ public:
         private_nh.param<int>("z_axis_dir", z_axis_dir_, z_axis_dir_);
         private_nh.param<int>("y_axis_dir", y_axis_dir_, y_axis_dir_);
 
-        usb = new CComm(port_name, baudrate);
+        usb_ = new CComm(port_name_, baudrate_);
     }
 
     bool init() {

--- a/src/imu_node.cpp
+++ b/src/imu_node.cpp
@@ -207,7 +207,6 @@ public:
         while (ros::ok()) {
             tf::Quaternion q;
             sensor_msgs::Imu output_msg;
-            std_msgs::Float64MultiArray output_rpy;
             try{
                 ImuData data = getImuData();
                 if (data.flag == false){
@@ -244,8 +243,6 @@ public:
                     if(y_deg_avg_cnt>9){
                         y_deg_avg_cnt = 0;
                     }
-                    output_rpy.data.push_back(y_deg_avg);
-                    output_rpy.data.push_back(deg_to_rad(angular_z_deg));
                     q = tf::createQuaternionFromRPY(0.0, y_deg_avg, deg_to_rad(angular_z_deg));
                     tf::quaternionTFToMsg(q, output_msg.orientation);
                     imu_pub_.publish(output_msg);

--- a/src/imu_node.cpp
+++ b/src/imu_node.cpp
@@ -53,7 +53,6 @@ struct ImuData {
 class IMU {
 private:
     ros::Publisher imu_pub_;
-    ros::Publisher imu_rpy_pub_;
     ros::ServiceServer reset_service_;
     ros::ServiceServer carivrate_service_;
     CComm* usb_;
@@ -147,7 +146,6 @@ public:
 
     IMU(ros::NodeHandle node) :
         imu_pub_(node.advertise<sensor_msgs::Imu>("imu", 10)),
-        imu_rpy_pub_(node.advertise<std_msgs::Float64MultiArray>("imu_rpy",10)),
         reset_service_(node.advertiseService("imu_reset", &IMU::resetCallback, this)), 
         carivrate_service_(node.advertiseService("imu_caribrate", &IMU::caribrateCallback, this)),
         gyro_unit_(0.00836181640625), acc_unit_(0.0008192),imu_frame_("imu_link"),
@@ -250,7 +248,6 @@ public:
                     output_rpy.data.push_back(deg_to_rad(angular_z_deg));
                     q = tf::createQuaternionFromRPY(0.0, y_deg_avg, deg_to_rad(angular_z_deg));
                     tf::quaternionTFToMsg(q, output_msg.orientation);
-                    imu_rpy_pub_.publish(output_rpy);
                     imu_pub_.publish(output_msg);
                     old_angular_z_deg = angular_z_deg;
 


### PR DESCRIPTION
- IMUから，X軸方向の加速度が送信されるようになった( https://github.com/open-rdc/cit_embedded_imu/pull/2 )ことに合わせて，X軸方向の加速度をピッチ角として取り扱うようにした．
- X軸方向の加速度は-1〜1[g]の間で送信されてくるので，asin()でラジアン角に変換される
- ロール角は使わないのでPublishしない

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/open-rdc/cit_adis_imu/29)

<!-- Reviewable:end -->
